### PR TITLE
Add default implementation of debugDescription in MTSMotisObject.

### DIFF
--- a/MTSMotisObject.m
+++ b/MTSMotisObject.m
@@ -106,4 +106,11 @@
     return keys;
 }
 
+#pragma mark Debug Description
+
+- (NSString*)debugDescription
+{
+    return [self mts_description];
+}
+
 @end


### PR DESCRIPTION
Default debugDescription in MTSMotisObject is very useful during debug.
